### PR TITLE
Support `<error>` element in JUnit XML

### DIFF
--- a/src/junitxml.ts
+++ b/src/junitxml.ts
@@ -69,6 +69,9 @@ export type TestCase = {
   failure?: {
     '@_message'?: string
   }
+  error?: {
+    '@_message'?: string
+  }
 }
 
 function assertTestCase(x: unknown): asserts x is TestCase {
@@ -90,6 +93,13 @@ function assertTestCase(x: unknown): asserts x is TestCase {
     assert(x.failure != null)
     if ('@_message' in x.failure) {
       assert(typeof x.failure['@_message'] === 'string')
+    }
+  }
+  if ('error' in x) {
+    assert(typeof x.error === 'object')
+    assert(x.error != null)
+    if ('@_message' in x.error) {
+      assert(typeof x.error['@_message'] === 'string')
     }
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -43,6 +43,10 @@ export const run = async (inputs: Inputs): Promise<void> => {
     core.info(`Processing ${junitXmlPath}`)
     const f = await fs.readFile(junitXmlPath)
     const junitXml = parseJunitXml(f)
+    core.startGroup(`Parsed ${junitXmlPath}`)
+    core.info(JSON.stringify(junitXml, undefined, 2))
+    core.endGroup()
+
     const metrics = getJunitXmlMetrics(junitXml, metricsContext)
 
     await metricsClient.submitMetrics(metrics.series, junitXmlPath)


### PR DESCRIPTION
Behave writes an `<error>` element to a test report.
https://github.com/behave/behave/blob/efeb7ac0123e76ce85c4283ecb3c697c0b7bcb16/behave/reporter/junit.py#L44-L50

This change will support `<error>` element.
